### PR TITLE
Add a lint gutter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import {
   INotebookTracker
 } from '@jupyterlab/notebook';
 
-import { 
+import {
   IEditorTracker
 } from '@jupyterlab/fileeditor';
 
@@ -63,7 +63,7 @@ class Linter {
   mainMenu: IMainMenu;
   state: IStateDB;
   term: Terminal;
-  
+
   prefsKey = `${id}:preferences`;
   settingsKey = `${id}:plugins`;
 
@@ -93,16 +93,16 @@ class Linter {
   process_mark: Function;           // default line marker processor
   os: string = '';             // operating system
   settingRegistry: ISettingRegistry;// settings
-  
-  constructor(app: JupyterFrontEnd, 
+
+  constructor(app: JupyterFrontEnd,
               notebookTracker: INotebookTracker,
               editorTracker: IEditorTracker,
-              palette: ICommandPalette, 
+              palette: ICommandPalette,
               mainMenu: IMainMenu,
               state: IStateDB,
               settingRegistry: ISettingRegistry
               ){
-   
+
     this.app = app;
     this.mainMenu = mainMenu;
     this.notebookTracker = notebookTracker;
@@ -177,7 +177,7 @@ class Linter {
     // try to connect to previous terminal, if not start a new one
     // TODO: still can't set the name of a terminal, so for now saving the "new"
     // terminal name in the settings (#16)
-    let session = await this.app.serviceManager.terminals 
+    let session = await this.app.serviceManager.terminals
       .connectTo(this.prefs.terminal_name)
       .catch(() => {
         this.log(`starting new terminal session`);
@@ -231,7 +231,7 @@ class Linter {
     }, 1000);
 
   }
-  
+
   private setup_terminal() {
 
     if (this.os === 'posix') {
@@ -307,6 +307,21 @@ class Linter {
 
     // select the notebook
     this.notebook = this.notebookTracker.currentWidget.content;
+    // debugger;
+    // AGHH
+    this.notebook.widgets.forEach((widget: any) => {
+      const gutters = widget.inputArea.editorWidget.editor._config.gutters;
+      // debugger;
+      // const xx = widget.inputArea.editor.setOption("gutters", [
+      //   "CodeMirror-lintgutter"
+      // ]);
+      if (!gutters.includes("CodeMirror-lintgutter")) {
+        widget.inputArea.editorWidget.editor._config.gutters.push(
+          "CodeMirror-lintgutter"
+        );
+      }
+    });
+    // debugger;
 
     // run on cell changing
     // this.notebookTracker.activeCellChanged.disconnect(this.onActiveCellChanged, this);
@@ -364,7 +379,7 @@ class Linter {
 
   /**
    * Generate lint command
-   * 
+   *
    * @param  {string} contents - contents of the notebook ready to be linted
    * @return {string} [description]
    */
@@ -478,7 +493,7 @@ class Linter {
 
     // load notebook
     this.cells = this.notebook.widgets;
-    
+
     this.log('getting notebook text');
 
     // return text from each cell if its a code cell
@@ -543,7 +558,7 @@ class Linter {
     if (!loc) {
       return;
     }
-   
+
     let from = {line: loc.line, ch: ch};
     let to = {line: loc.line, ch: ch+1};
 
@@ -689,7 +704,21 @@ class Linter {
    * @param {any}    to      [description]
    * @param {string} message [description]
    */
-  private mark_line(doc:any, from:any, to:any, message:string) {
+  private mark_line(doc: any, from: any, to: any, message: string) {
+    function makeMarker() {
+      var marker = document.createElement("div");
+      // marker.id = "fuck-bang";
+      marker.innerHTML = `<div class='jupyterlab-flake8-lint-gutter-container'>
+        <div>◉</div><div class='jupyterlab-flake8-lint-gutter-message'>${message}</div>
+      </div>`;
+      return marker;
+    }
+    const x = doc.cm.setGutterMarker(
+      from.line,
+      "CodeMirror-lintgutter",
+      makeMarker()
+    );
+    console.log(x, "/uGHgG");
 
     // mark the text
     this.marks.push(doc.markText(from, to,
@@ -707,7 +736,7 @@ class Linter {
       let lint_alert = document.createElement('span');
       let lint_message = document.createTextNode(`------ ${message}`);
       lint_alert.appendChild(lint_message);
-      lint_alert.className = 'jupyterlab-flake8-lint-message';  
+      lint_alert.className = 'jupyterlab-flake8-lint-message';
 
       // add error alert node to the 'to' location
       this.bookmarks.push(
@@ -718,7 +747,7 @@ class Linter {
     // this.bookmarks.push(doc.setBookmark({line: loc.lin, ch: ch}, {
     //   widget: lint_alert
     // }));
-    // 
+    //
 
     // window debugging
     // (<any>window).editor = editor;
@@ -733,7 +762,7 @@ class Linter {
    */
   private lint_cleanup() {
     this.linting = false;
-    // this.process_mark = undefined;  
+    // this.process_mark = undefined;
   }
 
   /**
@@ -771,7 +800,7 @@ class Linter {
         isToggled: () => { return this.prefs.toggled},
         execute: async () => {
           this.setPreference('toggled', !this.prefs.toggled);
-        } 
+        }
       },
       'flake8:show_error_messages': {
         label: "Show Flake8 Error Messages",
@@ -779,7 +808,7 @@ class Linter {
         isToggled: () => { return this.prefs.show_error_messages},
         execute: async () => {
           this.setPreference('show_error_messages', !this.prefs.show_error_messages);
-        } 
+        }
       },
       'flake8:show_browser_logs': {
         label: "Output Flake8 Browser Console Logs",
@@ -787,7 +816,7 @@ class Linter {
         isToggled: () => { return this.prefs.logging},
         execute: () => {
           this.setPreference('logging', !this.prefs.logging);
-        } 
+        }
       }
     };
 
@@ -842,10 +871,11 @@ class Linter {
 /**
  * Activate extension
  */
-function activate(app: JupyterFrontEnd, 
+<<<<<<< Updated upstream
+function activate(app: JupyterFrontEnd,
                   notebookTracker: INotebookTracker,
                   editorTracker: IEditorTracker,
-                  palette: ICommandPalette, 
+                  palette: ICommandPalette,
                   mainMenu: IMainMenu,
                   state: IStateDB,
                   settingRegistry: ISettingRegistry
@@ -855,6 +885,29 @@ function activate(app: JupyterFrontEnd,
 
 };
 
+=======
+function activate(
+  app: JupyterFrontEnd,
+  notebookTracker: INotebookTracker,
+  editorTracker: IEditorTracker,
+  palette: ICommandPalette,
+  mainMenu: IMainMenu,
+  state: IStateDB,
+  settingRegistry: ISettingRegistry
+) {
+  // debugger;
+  // console.log("fuck");
+  new Linter(
+    app,
+    notebookTracker,
+    editorTracker,
+    palette,
+    mainMenu,
+    state,
+    settingRegistry
+  );
+}
+>>>>>>> Stashed changes
 
 /**
  * Initialization data for the jupyterlab-flake8 extension.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,56 +1,42 @@
 import {
-  JupyterFrontEnd, JupyterFrontEndPlugin
-} from '@jupyterlab/application';
+  JupyterFrontEnd,
+  JupyterFrontEndPlugin
+} from "@jupyterlab/application";
 
-import {
-  ICommandPalette
-} from '@jupyterlab/apputils';
+import { ICommandPalette } from "@jupyterlab/apputils";
 
-import {
-  IMainMenu
-} from '@jupyterlab/mainmenu';
+import { IMainMenu } from "@jupyterlab/mainmenu";
 
-import {
-  INotebookTracker
-} from '@jupyterlab/notebook';
+import { INotebookTracker } from "@jupyterlab/notebook";
 
-import {
-  IEditorTracker
-} from '@jupyterlab/fileeditor';
+import { IEditorTracker } from "@jupyterlab/fileeditor";
 
-import {
-  IStateDB,
-  ISettingRegistry
-} from '@jupyterlab/coreutils';
+import { IStateDB, ISettingRegistry } from "@jupyterlab/coreutils";
 
-import {
-  Terminal
-} from '@jupyterlab/terminal';
+import { Terminal } from "@jupyterlab/terminal";
 
 import {
   Cell // ICellModel
-} from '@jupyterlab/cells';
+} from "@jupyterlab/cells";
 
-import {
-  CodeMirrorEditor
-} from '@jupyterlab/codemirror';
+import { CodeMirrorEditor } from "@jupyterlab/codemirror";
 
-import * as CodeMirror from 'codemirror';
+import * as CodeMirror from "codemirror";
 
 // CSS
-import '../style/index.css';
+import "../style/index.css";
 
 // extension id
 const id = `jupyterlab-flake8`;
 
 class Preferences {
-  toggled:Boolean;                 // turn on/off linter
-  logging:Boolean;                 // turn on/off logging
-  highlight_color:string;          // color of highlights
-  show_error_messages: Boolean;    // show error message
-  term_timeout:number;             // seconds before the temrinal times out if it has not received a message
-  conda_env:string;                // conda environment
-  terminal_name:string;            // persistent terminal to share between session
+  toggled: Boolean; // turn on/off linter
+  logging: Boolean; // turn on/off logging
+  highlight_color: string; // color of highlights
+  show_error_messages: Boolean; // show error message
+  term_timeout: number; // seconds before the temrinal times out if it has not received a message
+  conda_env: string; // conda environment
+  terminal_name: string; // persistent terminal to share between session
 }
 /**
  * Linter
@@ -68,41 +54,41 @@ class Linter {
   settingsKey = `${id}:plugins`;
 
   // Default Options
-  prefs =  new Preferences();
+  prefs = new Preferences();
 
   // flags
-  loaded: boolean = false;              // flag if flake8 is available
-  linting: boolean = false;             // flag if the linter is processing
-  termTimeoutHandle: number;            // flag if the linter is processing
+  loaded: boolean = false; // flag if flake8 is available
+  linting: boolean = false; // flag if the linter is processing
+  termTimeoutHandle: number; // flag if the linter is processing
 
   // notebook
-  cell_text: Array<string>;           // current nb cells
-  cells: Array<any>;                  // widgets from notebook
-  notebook: any;                      // current nb cells
-  lookup: any;                        // lookup of line index
+  cell_text: Array<string>; // current nb cells
+  cells: Array<any>; // widgets from notebook
+  notebook: any; // current nb cells
+  lookup: any; // lookup of line index
 
   // editor
-  editor: any;                        // current file editor widget
-  editortext: any;                    // current file editor text
+  editor: any; // current file editor widget
+  editortext: any; // current file editor text
 
   // cache
-  cache: Array<any> = [];            // cache for messages
+  cache: Array<any> = []; // cache for messages
   marks: Array<CodeMirror.TextMarker> = []; // text marker objects currently active
-  bookmarks: Array<any> = [];         // text marker objects currently active
-  text: string = '';                // current nb text
-  process_mark: Function;           // default line marker processor
-  os: string = '';             // operating system
-  settingRegistry: ISettingRegistry;// settings
+  bookmarks: Array<any> = []; // text marker objects currently active
+  text: string = ""; // current nb text
+  process_mark: Function; // default line marker processor
+  os: string = ""; // operating system
+  settingRegistry: ISettingRegistry; // settings
 
-  constructor(app: JupyterFrontEnd,
-              notebookTracker: INotebookTracker,
-              editorTracker: IEditorTracker,
-              palette: ICommandPalette,
-              mainMenu: IMainMenu,
-              state: IStateDB,
-              settingRegistry: ISettingRegistry
-              ){
-
+  constructor(
+    app: JupyterFrontEnd,
+    notebookTracker: INotebookTracker,
+    editorTracker: IEditorTracker,
+    palette: ICommandPalette,
+    mainMenu: IMainMenu,
+    state: IStateDB,
+    settingRegistry: ISettingRegistry
+  ) {
     this.app = app;
     this.mainMenu = mainMenu;
     this.notebookTracker = notebookTracker;
@@ -112,23 +98,28 @@ class Linter {
     this.settingRegistry = settingRegistry;
 
     // load settings from the registry
-    Promise.all([this.settingRegistry.load(this.settingsKey), app.restored])
-      .then(([settings]) => {
-        this.update_settings(settings, true);
+    Promise.all([
+      this.settingRegistry.load(this.settingsKey),
+      app.restored
+    ]).then(([settings]) => {
+      this.update_settings(settings, true);
 
-        // callback to update settings on changes
-        settings.changed.connect((settings:ISettingRegistry.ISettings) => {
-          this.update_settings(settings);
-        });
-
-        // on first load, if linter enabled, start it up
-        if (this.prefs.toggled) {
-          this.load_linter();
-        }
+      // callback to update settings on changes
+      settings.changed.connect((settings: ISettingRegistry.ISettings) => {
+        this.update_settings(settings);
       });
 
+      // on first load, if linter enabled, start it up
+      if (this.prefs.toggled) {
+        this.load_linter();
+      }
+    });
+
     // activate function when cell changes
-    this.notebookTracker.currentChanged.connect(this.onActiveNotebookChanged, this);
+    this.notebookTracker.currentChanged.connect(
+      this.onActiveNotebookChanged,
+      this
+    );
 
     // activate when editor changes
     this.editorTracker.currentChanged.connect(this.onActiveEditorChanged, this);
@@ -141,11 +132,14 @@ class Linter {
    * Update settings callback
    * @param {ISettingRegistry.ISettings} settings
    */
-  private update_settings(settings:ISettingRegistry.ISettings, first_load:Boolean=false) {
+  private update_settings(
+    settings: ISettingRegistry.ISettings,
+    first_load: Boolean = false
+  ) {
     let old = JSON.parse(JSON.stringify(this.prefs)); // copy old prefs
 
     // set settings to prefs object
-    Object.keys(settings.composite).forEach((key:string) => {
+    Object.keys(settings.composite).forEach((key: string) => {
       (<any>this.prefs)[key] = (<any>settings.composite)[key];
     });
     this.log(`loaded settings ${JSON.stringify(this.prefs)}`);
@@ -156,7 +150,10 @@ class Linter {
     }
 
     // and error messages
-    if (!first_load && old.show_error_messages !== this.prefs.show_error_messages) {
+    if (
+      !first_load &&
+      old.show_error_messages !== this.prefs.show_error_messages
+    ) {
       this.toggle_error_messages();
     }
   }
@@ -164,11 +161,12 @@ class Linter {
   /**
    * Load terminal session and flake8
    */
-  private async load_linter(){
-
+  private async load_linter() {
     // Bail if there are no terminals available.
     if (!this.app.serviceManager.terminals.isAvailable()) {
-      this.log('Disabling jupyterlab-flake8 plugin because it cant access terminal');
+      this.log(
+        "Disabling jupyterlab-flake8 plugin because it cant access terminal"
+      );
       this.loaded = false;
       this.prefs.toggled = false;
       return;
@@ -181,36 +179,39 @@ class Linter {
       .connectTo(this.prefs.terminal_name)
       .catch(() => {
         this.log(`starting new terminal session`);
-        return this.app.serviceManager.terminals.startNew()
+        return this.app.serviceManager.terminals.startNew();
       });
 
     // save terminal name
-    this.setPreference('terminal_name', session.name);
+    this.setPreference("terminal_name", session.name);
 
     // start a new terminal session
     this.log(`set terminal_name to ${session.name}`);
     this.term = new Terminal(session);
 
     // get OS
-    function _get_OS(sender:any, msg: any) {
+    function _get_OS(sender: any, msg: any) {
       if (msg.content) {
-        let message:string = msg.content[0] as string;
+        let message: string = msg.content[0] as string;
         // throw away non-strings
-        if (typeof(message) !== 'string') {
+        if (typeof message !== "string") {
           return;
         }
 
-        if (message.indexOf('command not found') > -1 ) {
+        if (message.indexOf("command not found") > -1) {
           this.log(`python command failed on this machine`);
           this.term.session.messageReceived.disconnect(_get_OS, this);
           this.finish_load();
         }
 
         // set OS
-        if (message.indexOf('posix') > -1) {
-          this.os = 'posix';
-        } else if (message.indexOf('nt(') === -1 && message.indexOf('nt') > -1) {
-          this.os = 'nt';
+        if (message.indexOf("posix") > -1) {
+          this.os = "posix";
+        } else if (
+          message.indexOf("nt(") === -1 &&
+          message.indexOf("nt") > -1
+        ) {
+          this.os = "nt";
         } else {
           return;
         }
@@ -227,19 +228,20 @@ class Linter {
     // wait a moment for terminal to load and then ask for OS
     setTimeout(() => {
       this.term.session.messageReceived.connect(_get_OS, this);
-      this.term.session.send({type: 'stdin', content: [`python -c "import os; print(os.name)"\r`]});
+      this.term.session.send({
+        type: "stdin",
+        content: [`python -c "import os; print(os.name)"\r`]
+      });
     }, 1000);
-
   }
 
   private setup_terminal() {
-
-    if (this.os === 'posix') {
-      this.term.session.send({type: 'stdin', content: [`HISTFILE= ;\r`]});
+    if (this.os === "posix") {
+      this.term.session.send({ type: "stdin", content: [`HISTFILE= ;\r`] });
     }
 
     // custom conda-env
-    if (this.prefs.conda_env !== 'base') {
+    if (this.prefs.conda_env !== "base") {
       this.set_env();
     } else {
       this.finish_load();
@@ -249,10 +251,16 @@ class Linter {
   // activate specific conda environment
   private set_env() {
     this.log(`conda env: ${this.prefs.conda_env}`);
-    if (this.os === 'posix') {
-      this.term.session.send({type: 'stdin', content: [`source activate ${this.prefs.conda_env}\r`]});
-    } else if (this.os !== 'posix') {
-      this.term.session.send({type: 'stdin', content: [`activate ${this.prefs.conda_env}\r`]});
+    if (this.os === "posix") {
+      this.term.session.send({
+        type: "stdin",
+        content: [`source activate ${this.prefs.conda_env}\r`]
+      });
+    } else if (this.os !== "posix") {
+      this.term.session.send({
+        type: "stdin",
+        content: [`activate ${this.prefs.conda_env}\r`]
+      });
     }
 
     this.finish_load();
@@ -264,15 +272,14 @@ class Linter {
       setTimeout(() => {
         this.loaded = true;
         this.activate_flake8();
-      }, 500)
-    } catch(e) {
+      }, 500);
+    } catch (e) {
       this.loaded = false;
       this.prefs.toggled = false;
       this.term.dispose();
       this.term = undefined;
     }
   }
-
 
   /**
    * Activate flake8 terminal reader
@@ -340,11 +347,10 @@ class Linter {
       if (!this.linting) {
         this.lint_notebook();
       } else {
-        this.log('flake8 is already running onActiveCellChanged');
+        this.log("flake8 is already running onActiveCellChanged");
       }
     }
   }
-
 
   /**
    * load linter when active editor loads
@@ -361,7 +367,6 @@ class Linter {
     // run on stateChanged
     this.editor.model.stateChanged.disconnect(this.onActiveEditorChanges, this);
     this.editor.model.stateChanged.connect(this.onActiveEditorChanges, this);
-
   }
 
   /**
@@ -372,7 +377,7 @@ class Linter {
       if (!this.linting) {
         this.lint_editor();
       } else {
-        this.log('flake8 is already running onEditorChanged');
+        this.log("flake8 is already running onEditorChanged");
       }
     }
   }
@@ -383,36 +388,36 @@ class Linter {
    * @param  {string} contents - contents of the notebook ready to be linted
    * @return {string} [description]
    */
-  private lint_cmd(contents:string): string {
-    let escaped = contents.replace(/["`\\]/g,'\\$&');
+  private lint_cmd(contents: string): string {
+    let escaped = contents.replace(/["`\\]/g, "\\$&");
     // escaped = contents.replace(/[\\]/g,'\\$&');   // escape escapes
-    escaped = escaped.replace('\r','');  // replace carriage returns
+    escaped = escaped.replace("\r", ""); // replace carriage returns
 
     // ignore magics by commenting
     escaped = escaped
-      .split('\n')
-      .map((line:string) => {
-        if (line.indexOf('%%') > -1) {
+      .split("\n")
+      .map((line: string) => {
+        if (line.indexOf("%%") > -1) {
           return `# ${line}`;
         } else {
           return line;
         }
       })
-      .join('\n');
+      .join("\n");
 
     // remove final \n (#20)
-    if (escaped.endsWith('\n')) {
+    if (escaped.endsWith("\n")) {
       escaped = escaped.slice(0, -1);
     }
 
-    return `(echo "${escaped}" | flake8 --exit-zero - && echo "@jupyterlab-flake8 finished linting" ) || (echo "@jupyterlab-flake8 finished linting failed")`
+    return `(echo "${escaped}" | flake8 --exit-zero - && echo "@jupyterlab-flake8 finished linting" ) || (echo "@jupyterlab-flake8 finished linting failed")`;
   }
 
   /**
    * Determine if text is input
    * @param {string} text [description]
    */
-  private text_exists(text:string) {
+  private text_exists(text: string) {
     return text;
     // return text && text !== '\n' && text !== '\n\n';
   }
@@ -421,7 +426,7 @@ class Linter {
    * Clear all current marks from code mirror
    */
   private clear_marks() {
-    this.marks.forEach((mark:CodeMirror.TextMarker) => {
+    this.marks.forEach((mark: CodeMirror.TextMarker) => {
       mark.clear();
     });
 
@@ -436,7 +441,7 @@ class Linter {
    * Clear all error messages
    */
   private clear_error_messages() {
-    this.bookmarks.forEach((bookmark:any) => {
+    this.bookmarks.forEach((bookmark: any) => {
       bookmark.clear();
     });
   }
@@ -445,13 +450,15 @@ class Linter {
    * Lint the CodeMirror Editor
    */
   private lint_editor() {
-    this.linting = true;  // no way to turn this off yet
+    this.linting = true; // no way to turn this off yet
     this.process_mark = this.mark_editor;
 
-
     // catch if file is not a .py file
-    if (this.editor.context.path.indexOf('.py') > -1 || this.editor.model._defaultLang === 'python') {
-      this.log('getting editor text from python file');
+    if (
+      this.editor.context.path.indexOf(".py") > -1 ||
+      this.editor.model._defaultLang === "python"
+    ) {
+      this.log("getting editor text from python file");
     } else {
       this.log(`not python default lang`);
       this.lint_cleanup();
@@ -468,15 +475,15 @@ class Linter {
    * @param {number} ch      [description]
    * @param {string} message [description]
    */
-  private mark_editor(line:number, ch:number) {
+  private mark_editor(line: number, ch: number) {
     this.log(`marking editor`);
 
     line = line - 1; // 0 index
-    ch = ch - 1;  // not sure
+    ch = ch - 1; // not sure
 
     // get lines
-    let from = {line: line, ch: ch};
-    let to = {line: line, ch: ch+1};
+    let from = { line: line, ch: ch };
+    let to = { line: line, ch: ch + 1 };
 
     // get code mirror editor
     let doc = this.editor.editorWidget.editor.doc;
@@ -488,40 +495,41 @@ class Linter {
    * Run flake8 linting on notebook cells
    */
   private lint_notebook() {
-    this.linting = true;  // no way to turn this off yet
+    this.linting = true; // no way to turn this off yet
     this.process_mark = this.mark_notebook;
 
     // load notebook
     this.cells = this.notebook.widgets;
 
-    this.log('getting notebook text');
+    this.log("getting notebook text");
 
     // return text from each cell if its a code cell
-    this.cell_text = this.cells
-      .map((cell:any, cell_idx:number, cell_arr: any[]) => {
-        if (cell.model.type === 'code' && this.text_exists(cell.model.value.text)) {
-
+    this.cell_text = this.cells.map(
+      (cell: any, cell_idx: number, cell_arr: any[]) => {
+        if (
+          cell.model.type === "code" &&
+          this.text_exists(cell.model.value.text)
+        ) {
           // append \n\n if its not the last cell
           if (cell_idx !== cell_arr.length - 1) {
             return `${cell.model.value.text}\n\n`;
           } else {
             return cell.model.value.text;
           }
-
         } else {
-          return '';
+          return "";
         }
-      });
+      }
+    );
 
     // create dictionary of lines
     this.lookup = {};
     let line = 1;
-    this.cell_text.map((cell:any, cell_idx:number, cell_arr:any[]) => {
-
+    this.cell_text.map((cell: any, cell_idx: number, cell_arr: any[]) => {
       // if there is text in the cell,
       if (this.text_exists(cell)) {
-        let lines = cell.split('\n');
-        for (let idx = 0; idx < lines.length-1; idx++) {
+        let lines = cell.split("\n");
+        for (let idx = 0; idx < lines.length - 1; idx++) {
           this.lookup[line] = {
             cell: cell_idx,
             line: idx
@@ -531,16 +539,16 @@ class Linter {
       }
 
       // if its the last cell in the notebook and its empty
-      else if (cell_idx === cell_arr.length-1) {
+      else if (cell_idx === cell_arr.length - 1) {
         this.lookup[line] = {
           cell: cell_idx,
           line: 0
-        }
+        };
       }
     });
 
     // join cells with text with two new lines
-    let pytext =  this.cell_text.join('');
+    let pytext = this.cell_text.join("");
 
     // run linter
     this.lint(pytext);
@@ -551,46 +559,46 @@ class Linter {
    * @param {number} line    the line # returned by flake8
    * @param {number} ch      the character # returned by flake 8
    */
-  private mark_notebook(line:number, ch:number) {
+  private mark_notebook(line: number, ch: number) {
     let loc = this.lookup[line];
-    ch = ch - 1;  // make character 0 indexed
+    ch = ch - 1; // make character 0 indexed
 
     if (!loc) {
       return;
     }
 
-    let from = {line: loc.line, ch: ch};
-    let to = {line: loc.line, ch: ch+1};
+    let from = { line: loc.line, ch: ch };
+    let to = { line: loc.line, ch: ch + 1 };
 
     // get cell instance
-    let cell:Cell = this.notebook.widgets[loc.cell];
+    let cell: Cell = this.notebook.widgets[loc.cell];
 
     // get cell's code mirror editor
-    let editor:CodeMirrorEditor = cell.inputArea.editorWidget.editor as CodeMirrorEditor;
+    let editor: CodeMirrorEditor = cell.inputArea.editorWidget
+      .editor as CodeMirrorEditor;
     let doc = editor.doc;
 
     return [doc, from, to];
   }
 
-
   /**
    * Lint a python text message and callback marking function with line and character
    * @param {string}   pytext        [description]
    */
-  private lint(pytext:string) {
-
+  private lint(pytext: string) {
     // cache pytext on text
     if (pytext !== this.text) {
       this.text = pytext;
-    } else {  // text has not changed
-      this.log('text unchanged');
+    } else {
+      // text has not changed
+      this.log("text unchanged");
       this.lint_cleanup();
       return;
     }
 
     // TODO: handle if text is empty (any combination of '' and \n)
     if (!this.text_exists(this.text)) {
-      this.log('text empty');
+      this.log("text empty");
       this.lint_cleanup();
       return;
     }
@@ -599,19 +607,21 @@ class Linter {
     this.clear_marks();
 
     // get lint command to run in terminal and send to terminal
-    this.log('preparing lint command');
+    this.log("preparing lint command");
     let lint_cmd = this.lint_cmd(pytext);
-    this.log('sending lint command');
-    this.term.session.send({type: 'stdin', content: [`${lint_cmd}\r`]})
+    this.log("sending lint command");
+    this.term.session.send({ type: "stdin", content: [`${lint_cmd}\r`] });
     this.termTimeoutHandle = setTimeout(() => {
-      if (this.linting = true) {
-        this.log('lint command timed out');
-        alert('jupyterlab-flake8 ran into an issue connecting with the terminal. Please try reloading the browser or re-installing the jupyterlab-flake8 extension.');
+      if ((this.linting = true)) {
+        this.log("lint command timed out");
+        alert(
+          "jupyterlab-flake8 ran into an issue connecting with the terminal. Please try reloading the browser or re-installing the jupyterlab-flake8 extension."
+        );
         this.lint_cleanup();
         this.dispose_linter();
         this.prefs.toggled = false;
       }
-    }, this.prefs.term_timeout)
+    }, this.prefs.term_timeout);
   }
 
   /**
@@ -620,13 +630,13 @@ class Linter {
    * @param {any} sender [description]
    * @param {any} msg    [description]
    */
-  private onLintMessage(sender:any, msg:any): void {
-    clearTimeout(this.termTimeoutHandle)
+  private onLintMessage(sender: any, msg: any): void {
+    clearTimeout(this.termTimeoutHandle);
     if (msg.content) {
-      let message:string = msg.content[0] as string;
+      let message: string = msg.content[0] as string;
 
       // catch non-strings
-      if (typeof(message) !== 'string') {
+      if (typeof message !== "string") {
         return;
       }
 
@@ -634,32 +644,35 @@ class Linter {
       this.log(`terminal message: ${message}`);
 
       // if message a is a reflection of the command, return
-      if (message.indexOf('Traceback') > -1) {
-        alert(`Flake8 encountered a python error. Make sure flake8 is installed and on the system path. \n\nTraceback: ${message}`);
+      if (message.indexOf("Traceback") > -1) {
+        alert(
+          `Flake8 encountered a python error. Make sure flake8 is installed and on the system path. \n\nTraceback: ${message}`
+        );
         this.lint_cleanup();
         return;
       }
 
       // if message a is a reflection of the command, return
-      if (message.indexOf('command not found') > -1 ) {
-        alert(`Flake8 was not found in this python environment. \n\nIf you are using a conda environment, set the 'conda_env' setting in the Advanced Settings menu and reload the Jupyter Lab window.\n\nIf you are not using a conda environment, Install Flake8 with 'pip install flake8' or 'conda install flake8' and reload the Jupyter Lab window`);
+      if (message.indexOf("command not found") > -1) {
+        alert(
+          `Flake8 was not found in this python environment. \n\nIf you are using a conda environment, set the 'conda_env' setting in the Advanced Settings menu and reload the Jupyter Lab window.\n\nIf you are not using a conda environment, Install Flake8 with 'pip install flake8' or 'conda install flake8' and reload the Jupyter Lab window`
+        );
         this.lint_cleanup();
         return;
       }
 
-      message.split('\n').forEach(m => {
-        if (m.includes('stdin:')) {
-          let idxs = m.split(':');
+      message.split("\n").forEach(m => {
+        if (m.includes("stdin:")) {
+          let idxs = m.split(":");
           let line = parseInt(idxs[1]);
           let ch = parseInt(idxs[2]);
           this.get_mark(line, ch, idxs[3]);
         }
       });
 
-      if (message.indexOf('jupyterlab-flake8 finished linting') > -1) {
+      if (message.indexOf("jupyterlab-flake8 finished linting") > -1) {
         this.lint_cleanup();
       }
-
     }
   }
 
@@ -669,13 +682,13 @@ class Linter {
    * @param {number} ch      [description]
    * @param {string} message [description]
    */
-  private get_mark(line:number, ch:number, message:string) {
+  private get_mark(line: number, ch: number, message: string) {
     let doc, from, to;
     try {
-      if (this.process_mark && typeof(this.process_mark) === 'function') {
+      if (this.process_mark && typeof this.process_mark === "function") {
         [doc, from, to] = this.process_mark(line, ch);
       }
-    } catch(e) {
+    } catch (e) {
       this.log(`failed to run process_mark`);
       return;
     }
@@ -696,7 +709,6 @@ class Linter {
     this.mark_line(doc, from, to, message);
   }
 
-
   /**
    * Mark line in document
    * @param {any}    doc     [description]
@@ -707,7 +719,6 @@ class Linter {
   private mark_line(doc: any, from: any, to: any, message: string) {
     function makeMarker() {
       var marker = document.createElement("div");
-      // marker.id = "fuck-bang";
       marker.innerHTML = `<div class='jupyterlab-flake8-lint-gutter-container'>
         <div>◉</div><div class='jupyterlab-flake8-lint-gutter-message'>${message}</div>
       </div>`;
@@ -721,27 +732,25 @@ class Linter {
     console.log(x, "/uGHgG");
 
     // mark the text
-    this.marks.push(doc.markText(from, to,
-      {
+    this.marks.push(
+      doc.markText(from, to, {
         // replacedWith: selected_char_node,
-        className: 'jupyterlab-flake8-lint-message',
+        className: "jupyterlab-flake8-lint-message",
         css: `
           background-color: ${this.prefs.highlight_color}
         `
-      }));
+      })
+    );
 
-    // TODO: show this is a hover-over bubble
     // create error alert node
     if (this.prefs.show_error_messages) {
-      let lint_alert = document.createElement('span');
+      let lint_alert = document.createElement("span");
       let lint_message = document.createTextNode(`------ ${message}`);
       lint_alert.appendChild(lint_message);
-      lint_alert.className = 'jupyterlab-flake8-lint-message';
+      lint_alert.className = "jupyterlab-flake8-lint-message";
 
       // add error alert node to the 'to' location
-      this.bookmarks.push(
-        (<any>doc).addLineWidget(from.line, lint_alert)
-      );
+      this.bookmarks.push((<any>doc).addLineWidget(from.line, lint_alert));
     }
 
     // this.bookmarks.push(doc.setBookmark({line: loc.lin, ch: ch}, {
@@ -769,15 +778,14 @@ class Linter {
    * Show browser logs
    * @param {any} msg [description]
    */
-  private log(msg:any) {
-
+  private log(msg: any) {
     // return if prefs.logging is not enabled
     if (!this.prefs.logging) {
       return;
     }
 
     // convert object messages to strings
-    if (typeof(msg) === 'object') {
+    if (typeof msg === "object") {
       msg = JSON.stringify(msg);
     }
 
@@ -789,33 +797,48 @@ class Linter {
   /**
    * Create menu / command items
    */
-  add_commands(){
-    let category = 'Flake8';
+  add_commands() {
+    let category = "Flake8";
 
     // define all commands
-    let commands:any = {
-      'flake8:toggle': {
+    let commands: any = {
+      "flake8:toggle": {
         label: "Enable Flake8",
-        isEnabled: () => { return this.loaded},
-        isToggled: () => { return this.prefs.toggled},
+        isEnabled: () => {
+          return this.loaded;
+        },
+        isToggled: () => {
+          return this.prefs.toggled;
+        },
         execute: async () => {
-          this.setPreference('toggled', !this.prefs.toggled);
+          this.setPreference("toggled", !this.prefs.toggled);
         }
       },
-      'flake8:show_error_messages': {
+      "flake8:show_error_messages": {
         label: "Show Flake8 Error Messages",
-        isEnabled: () => { return this.loaded},
-        isToggled: () => { return this.prefs.show_error_messages},
+        isEnabled: () => {
+          return this.loaded;
+        },
+        isToggled: () => {
+          return this.prefs.show_error_messages;
+        },
         execute: async () => {
-          this.setPreference('show_error_messages', !this.prefs.show_error_messages);
+          this.setPreference(
+            "show_error_messages",
+            !this.prefs.show_error_messages
+          );
         }
       },
-      'flake8:show_browser_logs': {
+      "flake8:show_browser_logs": {
         label: "Output Flake8 Browser Console Logs",
-        isEnabled: () => { return this.loaded},
-        isToggled: () => { return this.prefs.logging},
+        isEnabled: () => {
+          return this.loaded;
+        },
+        isToggled: () => {
+          return this.prefs.logging;
+        },
         execute: () => {
-          this.setPreference('logging', !this.prefs.logging);
+          this.setPreference("logging", !this.prefs.logging);
         }
       }
     };
@@ -823,17 +846,22 @@ class Linter {
     // add commands to menus and palette
     for (let key in commands) {
       this.app.commands.addCommand(key, commands[key]);
-      this.palette.addItem({command: key, category: category} );
+      this.palette.addItem({ command: key, category: category });
     }
 
     // add to view Menu
-    this.mainMenu.viewMenu.addGroup(Object.keys(commands).map(key => {return {command: key} }), 30);
+    this.mainMenu.viewMenu.addGroup(
+      Object.keys(commands).map(key => {
+        return { command: key };
+      }),
+      30
+    );
   }
 
-    /**
+  /**
    * Turn linting on/off
    */
-  private toggle_linter(){
+  private toggle_linter() {
     if (this.prefs.toggled) {
       this.load_linter();
     } else {
@@ -844,11 +872,11 @@ class Linter {
   /**
    * Turn error messages on/off
    */
-  private toggle_error_messages(){
+  private toggle_error_messages() {
     if (!this.prefs.show_error_messages) {
       this.clear_error_messages();
     } else if (this.cache && this.cache.length > 0) {
-      this.cache.forEach((mark) => {
+      this.cache.forEach(mark => {
         this.mark_line(mark.doc, mark.from, mark.to, mark.message);
       });
     }
@@ -857,35 +885,19 @@ class Linter {
   /**
    * Save state preferences
    */
-  private async setPreference(key:string, val:any) {
-
-    await Promise.all([this.settingRegistry.load(this.settingsKey), this.app.restored])
-      .then(([settings]) => {
-        settings.set(key, val); // will automatically call update
-      });
+  private async setPreference(key: string, val: any) {
+    await Promise.all([
+      this.settingRegistry.load(this.settingsKey),
+      this.app.restored
+    ]).then(([settings]) => {
+      settings.set(key, val); // will automatically call update
+    });
   }
-
 }
-
 
 /**
  * Activate extension
  */
-<<<<<<< Updated upstream
-function activate(app: JupyterFrontEnd,
-                  notebookTracker: INotebookTracker,
-                  editorTracker: IEditorTracker,
-                  palette: ICommandPalette,
-                  mainMenu: IMainMenu,
-                  state: IStateDB,
-                  settingRegistry: ISettingRegistry
-                  ) {
-
-  new Linter(app, notebookTracker, editorTracker, palette, mainMenu, state, settingRegistry);
-
-};
-
-=======
 function activate(
   app: JupyterFrontEnd,
   notebookTracker: INotebookTracker,
@@ -907,16 +919,22 @@ function activate(
     settingRegistry
   );
 }
->>>>>>> Stashed changes
 
 /**
  * Initialization data for the jupyterlab-flake8 extension.
  */
 const extension: JupyterFrontEndPlugin<void> = {
-  id: 'jupyterlab-flake8',
+  id: "jupyterlab-flake8",
   autoStart: true,
   activate: activate,
-  requires: [INotebookTracker, IEditorTracker, ICommandPalette, IMainMenu, IStateDB, ISettingRegistry]
+  requires: [
+    INotebookTracker,
+    IEditorTracker,
+    ICommandPalette,
+    IMainMenu,
+    IStateDB,
+    ISettingRegistry
+  ]
 };
 
 export default extension;

--- a/style/index.css
+++ b/style/index.css
@@ -1,9 +1,37 @@
-
-
-.jupyterlab-flake8-lint-message span { 
-    display: none 
+.jupyterlab-flake8-lint-message span {
+  display: none;
 }
 
-.jupyterlab-flake8-lint-message span:hover { 
-    display: block
+.jupyterlab-flake8-lint-message span:hover {
+  display: block;
+}
+
+.CodeMirror-lintgutter {
+  padding: 0 8px;
+}
+
+.jupyterlab-flake8-lint-gutter-container {
+  color: var(--jp-error-color0);
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  position: relative;
+}
+
+.jupyterlab-flake8-lint-gutter-message {
+  background: var(--jp-layout-color4);
+  border-radius: 4px;
+  color: white;
+  left: 16px;
+  padding: 2px 5px;
+  position: absolute;
+  top: 0;
+  visibility: hidden;
+  white-space: nowrap;
+  z-index: 1;
+}
+
+.jupyterlab-flake8-lint-gutter-container:hover
+  .jupyterlab-flake8-lint-gutter-message {
+  visibility: visible;
 }


### PR DESCRIPTION
This PR adds a lint gutter (ala Atom's lint gutter) which displays messages on hover. It addresses the TODO described in the readme "show error messages on hover rather than in a new line". I think the spirit of that comment is to have hover behavior over the marked part of the code, but that can be added reasonably easily if required.

![Screen Shot 2019-10-09 at 10 26 41 AM](https://user-images.githubusercontent.com/6854312/66496039-e1b51d00-ea7f-11e9-8dbf-fdf44036c765.png)


I have a PR open against jupyterlab as well (https://github.com/jupyterlab/jupyterlab/pull/7305) that adds enables custom gutters, which when it lands will enable less hacky gutter behavior. That said, (based on that thread) it seems like this mechanism of forcing the the gutter to exist is not un-standard. 

There are a lot of non-sense whitespace changes because prettier went a little hog wild on the file. If the prettier changes are annoying I can redo the PR without them. Additionally the extension could pull in jupyterlab's prettier config for consistency (which could either happen here or in another PR).