### PR TITLE
feat: add a configuration file option to preferences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ lib/
 # dependencies
 node_modules/
 *.egg-info/
-
+.vscode/*
+.flake8

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-flake8",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/schema/plugins.json
+++ b/schema/plugins.json
@@ -38,7 +38,13 @@
       "type": "string",
       "description": "Persistent internal terminal name. This is set automatically on each run",
       "default": ""
+    },
+    "configuration_file": {
+      "type": "string",
+      "description": "Base configuration file option to pass to flake8.",
+      "default": ""
     }
+
   },
   "additionalProperties": false,
   "type": "object"

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ class Preferences {
   term_timeout: number; // seconds before the temrinal times out if it has not received a message
   conda_env: string; // conda environment
   terminal_name: string; // persistent terminal to share between session
+  configuration_file: string; // global flake8 configuration file
 }
 /**
  * Linter
@@ -431,12 +432,18 @@ class Linter {
       }
     }
 
+    let config_option = '';
+
+    if (this.prefs.configuration_file !== null && this.prefs.configuration_file !== ''){
+      config_option = `--config="${this.prefs.configuration_file}"`;
+    }
+
     if (this.os === 'nt') {
       // powershell
-      return `echo "${escaped}" | flake8 --exit-zero - ; if($?) {echo "@jupyterlab-flake8 finished linting"} ; if (-not $?) {echo "@jupyterlab-flake8 finished linting failed"} `;
+      return `echo "${escaped}" | flake8 ${config_option} --exit-zero - ; if($?) {echo "@jupyterlab-flake8 finished linting"} ; if (-not $?) {echo "@jupyterlab-flake8 finished linting failed"} `;
     } else {
       // unix
-      return `(echo "${escaped}" | flake8 --exit-zero - && echo "@jupyterlab-flake8 finished linting" ) || (echo "@jupyterlab-flake8 finished linting failed")`;
+      return `(echo "${escaped}" | flake8 ${config_option} --exit-zero - && echo "@jupyterlab-flake8 finished linting" ) || (echo "@jupyterlab-flake8 finished linting failed")`;
     }
   }
 


### PR DESCRIPTION
Hello

I added a small feature to the extension. It is a new `configuration_file` preferences option, which is passed to the flake8 command if set.

It is not battle tested but does the job for people that wish to use a standard configuration of flake8 for all their notebooks.

Can you please consider it for integration ?

Regards